### PR TITLE
Update gResistor runtime to 46

### DIFF
--- a/eu.stethewwolf.gresistor.json
+++ b/eu.stethewwolf.gresistor.json
@@ -1,7 +1,7 @@
 {
     "app-id": "eu.stethewwolf.gresistor",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "gresistor3",
     "finish-args" : [

--- a/eu.stethewwolf.gresistor.json
+++ b/eu.stethewwolf.gresistor.json
@@ -26,6 +26,10 @@
                     "type": "git",
                     "url" : "https://github.com/stethewwolf/gResistor.git",
                     "commit": "997447836ecd3e1a1a0563c60fa44d0de15ea042"
+                },
+                {
+                    "type": "patch",
+                    "path": "fix_appdata.patch"
                 }
             ]
         }

--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,30 @@
+From ed637c39f38fefd0ae9a9c9c94d712d2d3c60be4 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sat, 8 Jun 2024 18:07:20 +0300
+Subject: [PATCH] appdata: Update appdata
+
+- Fix appdata papercuts
+---
+ eu.stethewwolf.gresistor.metainfo.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eu.stethewwolf.gresistor.metainfo.xml b/eu.stethewwolf.gresistor.metainfo.xml
+index 78ddceb..8b62b0a 100644
+--- a/eu.stethewwolf.gresistor.metainfo.xml
++++ b/eu.stethewwolf.gresistor.metainfo.xml
+@@ -1,4 +1,3 @@
+-
+ <?xml version="1.0" encoding="UTF-8"?>
+ <component type="desktop">
+     <id>eu.stethewwolf.gresistor</id>
+@@ -23,6 +22,7 @@
+     <url type="homepage">https://gresistor.stethewwolf.eu/</url>
+     <url type="help">https://gresistor.stethewwolf.eu/</url>
+     <url type="bugtracker">https://github.com/stethewwolf/gResistor/issues</url>
++    <url type="vcs-browser">https://gresistor.stethewwolf.eu/</url>
+     <developer_name>Stefano Prina</developer_name>
+     <screenshots>
+         <screenshot type="default">
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
- Update gResistor runtime to 46 since runtime version 44 has reached end-of-life.
- Fix appdata papercuts